### PR TITLE
Add github action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy to Linode
+
+on:
+    push:
+        branches: [main]
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
+
+            - name: Set up SSH
+              run: |
+                  mkdir -p ~/.ssh
+                  echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+                  chmod 600 ~/.ssh/id_ed25519
+                  ssh-keyscan -p ${{ secrets.SSH_PORT }} ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
+
+            - name: SSH into Linode and deploy
+              run: |
+                  ssh -p ${{ secrets.SSH_PORT }} ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} << 'EOF'
+                    cd /root/server
+                    git pull
+                    docker-compose up -d --build
+                  EOF


### PR DESCRIPTION
### TL;DR

Added GitHub Actions workflow to automatically deploy to Linode when changes are pushed to main branch.

### What changed?

Created a new GitHub Actions workflow file (`.github/workflows/deploy.yml`) that:
- Triggers on pushes to the main branch
- Sets up SSH access to the Linode server using repository secrets
- Connects to the server and runs deployment commands:
  - Pulls the latest code
  - Rebuilds and restarts Docker containers

### How to test?

1. Ensure the following secrets are configured in the repository:
   - `SSH_PRIVATE_KEY`: ED25519 private key for SSH authentication
   - `SSH_PORT`: Port number for SSH connection
   - `SSH_HOST`: Hostname or IP of the Linode server
   - `SSH_USER`: Username for SSH login

2. Push a change to the main branch and verify:
   - The workflow runs successfully in GitHub Actions
   - The server pulls the latest code
   - Docker containers are rebuilt and restarted

### Why make this change?

Automates the deployment process to eliminate manual steps when pushing changes to production, ensuring consistent and reliable deployments to the Linode server.