### PR TITLE
Serve README.md at the root

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# DeLesslin's Server
+
+Backend for www.delesslin.studio
+
+## Features:
+
+    - Serve portfolio data
+    - Serve bluesky bots
+    - Dashboard for editing and adding to portfolio
+    - Save static images/etc
+
+## Development Tasks
+
+-   [x] Get server running on linode
+-   [x] Get github actions working
+-   [x] Serve static html from README file
+-   [ ] Implement nginx
+-   [ ] Implement mongodb
+-   [ ] Start storing portfolio data in mongodb
+-   [ ] Migrate bluesky bots
+
+## Reference and Biblio
+
+[Showdown](https://github.com/showdownjs/showdown)

--- a/server/index.js
+++ b/server/index.js
@@ -1,10 +1,15 @@
 const express = require("express");
-
+const fs = require("fs").promises;
 const app = express();
-
-app.get("/", (req, res) => {
-    console.log("Received request.");
-    res.send("Tanake manu V2");
+const showdown = require("showdown");
+const converter = new showdown.Converter({
+    simplifiedAutoLink: true,
+    tasklists: true,
+});
+app.get("/", async (req, res) => {
+    const text = await fs.readFile("../README.md", "utf-8");
+    const html = converter.makeHtml(text);
+    res.send(html);
 });
 
 app.listen(3000, (err) => {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,8 @@
             "version": "0.0.1",
             "license": "ISC",
             "dependencies": {
-                "express": "^5.1.0"
+                "express": "^5.1.0",
+                "showdown": "^2.1.0"
             }
         },
         "node_modules/accepts": {
@@ -76,6 +77,14 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/commander": {
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+            "engines": {
+                "node": "^12.20.0 || >=14"
             }
         },
         "node_modules/content-disposition": {
@@ -627,6 +636,21 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
             "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+        },
+        "node_modules/showdown": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
+            "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
+            "dependencies": {
+                "commander": "^9.0.0"
+            },
+            "bin": {
+                "showdown": "bin/showdown.js"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://www.paypal.me/tiviesantos"
+            }
         },
         "node_modules/side-channel": {
             "version": "1.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -4,11 +4,13 @@
     "description": "",
     "main": "index.js",
     "scripts": {
-        "start": "node ."
+        "start": "node .",
+        "dev": "nodemon ."
     },
     "author": "delesslin",
     "license": "ISC",
     "dependencies": {
-        "express": "^5.1.0"
+        "express": "^5.1.0",
+        "showdown": "^2.1.0"
     }
 }


### PR DESCRIPTION
### TL;DR

Added a README file and implemented markdown rendering for the homepage.

### What changed?

- Created a new README.md file with project information, features, and development tasks
- Modified the server to render the README content as HTML on the homepage
- Added the Showdown library to convert markdown to HTML
- Updated package.json with the Showdown dependency and added a dev script

### How to test?

1. Install dependencies with `npm install`
2. Run the server with `npm start` or `npm run dev`
3. Visit the homepage in a browser to see the README content rendered as HTML

### Why make this change?

This change provides documentation for the project and improves the homepage by displaying useful information about the project's features and development status. Using the README content for the homepage ensures that documentation stays up-to-date and provides visitors with relevant information about the project.