### PR TITLE
Fix working directory issue for accessing README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
-# Use a lightweight Node.js base image
 FROM node:18-alpine
 
-# Set working directory inside the container
+# Start in /app
 WORKDIR /app
 
-# Copy and install dependencies
+# Copy everything into /app (including README.md and server/)
+COPY . .
+
+# Set working directory to the server
+WORKDIR /app/server
+
+# Install dependencies inside the server directory
 COPY server/package*.json ./
 RUN npm install
-
-# Copy the rest of the app
-COPY server .
 
 # Expose the app port
 EXPOSE 3000


### PR DESCRIPTION
### TL;DR

Fixed Docker build process to properly include all application files and set up the correct working directory structure.

### What changed?

- Restructured the Dockerfile to first copy the entire application into `/app`
- Added a step to change the working directory to `/app/server` before installing dependencies
- Fixed the dependency installation to happen in the correct directory
- Removed unnecessary comments and clarified the build process

### How to test?

1. Build the Docker image: `docker build -t app-image .`
2. Run the container: `docker run -p 3000:3000 app-image`
3. Verify the application starts correctly and can be accessed at http://localhost:3000

### Why make this change?

The previous Dockerfile had issues with file paths and working directories, which could cause the application to fail during container startup. This change ensures all files (including README.md and the entire server directory) are properly copied into the container and dependencies are installed in the correct location.