### PR TITLE
Add mongo to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,18 @@ services:
         ports:
             - "3000:3000"
         restart: always
+        depends_on:
+            - mongo
+        environment:
+            - MONGO_URI=mongodb://mongo:27017/mydb
+
+    mongo:
+        image: mongo:6
+        restart: always
+        volumes:
+            - mongo-data:/data/db
+        environment:
+            - MONGO_INITDB_DATABASE=mydb
+
+volumes:
+    mongo-data:


### PR DESCRIPTION
### TL;DR

Added MongoDB service to the Docker Compose configuration with proper connection to the existing application.

### What changed?

- Added MongoDB 6 as a new service in the docker-compose.yml
- Configured the existing service to depend on and connect to MongoDB
- Added environment variables for MongoDB connection
- Set up persistent volume storage for MongoDB data
- Configured database initialization with "mydb" as the default database

### How to test?

1. Run `docker-compose up -d` to start both services
2. Verify the application connects to MongoDB by checking logs: `docker-compose logs`
3. Test application functionality that relies on database operations
4. Verify data persistence by stopping and restarting the containers: `docker-compose down && docker-compose up -d`

### Why make this change?

This change adds database persistence to the application, allowing it to store and retrieve data reliably. Using MongoDB as a containerized service ensures consistent development environments and simplifies the deployment process while maintaining data integrity through volume mounting.